### PR TITLE
Sizereduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM ubuntu:14.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -q && apt-get install -y netbase python \
 	&& apt-get clean -y && rm -rf /var/lib/apt/lists/*
-ADD https://raw.github.com/pypa/pip/master/contrib/get-pip.py /get-pip.py    
-RUN python /get-pip.py
-RUN pip install "devpi-server>=2.0.6,<2.1dev" "devpi-client>=2.0.2,<2.1dev" \
-        "requests>=2.4.0,<2.5"
+ADD ["https://raw.github.com/pypa/pip/master/contrib/get-pip.py", "run.sh", "/"]
+RUN python /get-pip.py \
+	&& pip install "devpi-server>=2.0.6,<2.1dev" "devpi-client>=2.0.2,<2.1dev" \
+	"requests>=2.4.0,<2.5"
 VOLUME /mnt
 EXPOSE 3141
-ADD run.sh /
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update -q && apt-get install -y netbase python
+RUN apt-get update -q && apt-get install -y netbase python \
+	&& apt-get clean -y && rm -rf /var/lib/apt/lists/*
 ADD https://raw.github.com/pypa/pip/master/contrib/get-pip.py /get-pip.py    
 RUN python /get-pip.py
 RUN pip install "devpi-server>=2.0.6,<2.1dev" "devpi-client>=2.0.2,<2.1dev" \


### PR DESCRIPTION
1f608a0 is just a minor update to the Dockerfile to slim down the resulting image after build. This slims it down by about 20MB. Granted it's not a lot, but that's 20MB less to pull if done over a slow or capped connection.

2ae3e24 on the other hand squashes 4 directives down to 2.