### PR TITLE
Update devpi-server and devpi-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3
-RUN pip install "devpi-server>=2.5,<2.6dev" "devpi-client>=2.3,<=2.4dev"
+RUN pip install devpi-server==4.1.1 devpi-client==2.7.0
 VOLUME /mnt
 EXPOSE 3141
 ADD run.sh /

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@
 This repository contains **Dockerfile** of [Devpi](http://doc.devpi.net/) for [Docker](https://www.docker.io/)'s [trusted build](https://index.docker.io/u/scrapinghub/devpi/) published to the public [Docker Registry](https://index.docker.io/).
 
 
-### Dependencies
-
-* [dockerfile/ubuntu](http://dockerfile.github.io/#/ubuntu)
-
-
 ### Installation
 
 1. Install [Docker](https://www.docker.io/).

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 set -x
+export LOG_FILE=/mnt/.xproc/devpi-server/xprocess.log
 export DEVPI_SERVERDIR=/mnt
 export DEVPI_CLIENTDIR=/tmp/devpi-client
 [[ -f $DEVPI_SERVERDIR/.serverversion ]] || initialize=yes
@@ -27,13 +28,13 @@ if [[ $initialize = yes ]]; then
   devpi use http://localhost:3141
   devpi login root --password=''
   devpi user -m root password="${DEVPI_PASSWORD}"
-  devpi index -y -c public pypi_whitelist='*'
+  devpi index -y -c public pypi_whitelist='*' bases=root/pypi
 fi
 # We cannot simply execute tail, because otherwise bash won't propagate
 # incoming TERM signals to tail and will hang indefinitely.  Instead, we wait
 # on tail PID and then "wait" command will interrupt on TERM (or any other)
 # signal and the script will proceed to kill_* functions which will gracefully
 # terminate child processes.
-tail -f /etc/fstab & #"$LOG_FILE" &
+tail -f "$LOG_FILE" &
 TAIL_PID=$!
 wait $TAIL_PID


### PR DESCRIPTION
Use 4.1.1 and 2.6 versions accordingly.
Remove useless dependency from README
Show log in output, instead of just hang on fstab